### PR TITLE
Test upgraded to prove that a sink close works

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,10 @@ name := "akka-sse"
 
 libraryDependencies ++= List(
   Library.akkaHttp,
-  Library.junit      % "test",
-  Library.scalaCheck % "test",
-  Library.scalaTest  % "test"
+  Library.junit       % "test",
+  Library.akkaTestkit % "test",
+  Library.scalaCheck  % "test",
+  Library.scalaTest   % "test"
 )
 
 initialCommands := """|import de.heikoseeberger.akkasse._""".stripMargin

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Version {
   val akka       = "2.3.9"
   val akkaHttp   = "1.0-M4"
   val junit      = "4.12"
-  val scala      = "2.11.6"
+  val scala      = "2.11.5"
   val scalaCheck = "1.12.2"
   val scalaTest  = "2.2.4"
 }


### PR DESCRIPTION
The enhanced test proves that the problem reported by https://github.com/hseeberger/akka-sse/issues/12 is not a stream/akka-sse issue per se given that a downstream sink does indeed close this source.