### PR TITLE
Scale scalatest time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ scala:
 - 2.11.6
 jdk:
 - oraclejdk8
-script: sbt test
+script: sbt "testOnly * -- -F 2"

--- a/akka-sse/src/test/scala/de/heikoseeberger/akkasse/HeartbeatSourceSpec.scala
+++ b/akka-sse/src/test/scala/de/heikoseeberger/akkasse/HeartbeatSourceSpec.scala
@@ -56,7 +56,7 @@ class HeartbeatSourceSpec extends WordSpec with Matchers with BeforeAndAfterAll 
 
       for (n <- 1 to 4) eventPublisher ! 42
 
-      whenReady(source.grouped(8).runWith(Sink.head()), Timeout(Span(300, Millis))) { result =>
+      whenReady(source.grouped(8).runWith(Sink.head()), Timeout(scaled(Span(300, Millis)))) { result =>
         val events = result.groupBy(_.data)
         events("42").size shouldBe 4
         events("heartbeat").size shouldBe 4


### PR DESCRIPTION
`testOnly` is used, because `test` does not accept parameters to the testing framework from the CLI.