### PR TITLE
Add ServerSentEventSource type alias

### DIFF
--- a/akka-sse-example/src/main/scala/de/heikoseeberger/akkasse/example/TimeClient.scala
+++ b/akka-sse-example/src/main/scala/de/heikoseeberger/akkasse/example/TimeClient.scala
@@ -22,7 +22,7 @@ import akka.http.client.RequestBuilding.Get
 import akka.http.unmarshalling.Unmarshal
 import akka.stream.ActorFlowMaterializer
 import akka.stream.scaladsl.Source
-import de.heikoseeberger.akkasse.{ EventStreamUnmarshalling, ServerSentEvent }
+import de.heikoseeberger.akkasse.{ EventStreamUnmarshalling, ServerSentEvent, ServerSentEventSource }
 import java.time.LocalTime
 
 object TimeClient extends EventStreamUnmarshalling {
@@ -34,7 +34,7 @@ object TimeClient extends EventStreamUnmarshalling {
 
     Source.single(Get())
       .via(Http().outgoingConnection("127.0.0.1", 9000))
-      .mapAsync(Unmarshal(_).to[Source[ServerSentEvent, Unit]])
+      .mapAsync(Unmarshal(_).to[ServerSentEventSource])
       .runForeach(_.runForeach(event => println(s"${LocalTime.now()} $event")))
   }
 }

--- a/akka-sse/src/main/scala/de/heikoseeberger/akkasse/EventStreamUnmarshalling.scala
+++ b/akka-sse/src/main/scala/de/heikoseeberger/akkasse/EventStreamUnmarshalling.scala
@@ -37,8 +37,8 @@ object EventStreamUnmarshalling extends EventStreamUnmarshalling
  */
 trait EventStreamUnmarshalling {
 
-  implicit final def fromEntityUnmarshaller(implicit ec: ExecutionContext): FromEntityUnmarshaller[Source[ServerSentEvent, Unit]] = {
-    val unmarshaller: FromEntityUnmarshaller[Source[ServerSentEvent, Unit]] = Unmarshaller { entity =>
+  implicit final def fromEntityUnmarshaller(implicit ec: ExecutionContext): FromEntityUnmarshaller[ServerSentEventSource] = {
+    val unmarshaller: FromEntityUnmarshaller[ServerSentEventSource] = Unmarshaller { entity =>
       FastFuture.successful(entity.dataBytes.transform(() => new ServerSentEventParser(1048576))) // TODO Really hard-coded?
     }
     unmarshaller.forContentTypes(MediaTypes.`text/event-stream`)

--- a/akka-sse/src/main/scala/de/heikoseeberger/akkasse/package.scala
+++ b/akka-sse/src/main/scala/de/heikoseeberger/akkasse/package.scala
@@ -16,6 +16,17 @@
 
 package de.heikoseeberger
 
+import akka.stream.scaladsl.Source
+
 package object akkasse {
+
+  /**
+   * View from `A` to [[ServerSentEvent]].
+   */
   type ToServerSentEvent[A] = A => ServerSentEvent
+
+  /**
+   * Just a slightly nicer name for `Source[ServerSentEvent, Unit]`.
+   */
+  type ServerSentEventSource = Source[ServerSentEvent, Unit]
 }


### PR DESCRIPTION
Just a little convenience to avoid typing things like `....mapTo[Source[ServerSentEvent, Unit]]`, but instead `...mapTo[ServerSentEventSource]`.