### PR TITLE
`LineParser` now first tries to parse lines before checking the size of the buffer. 

### DIFF
--- a/akka-sse/src/main/scala/de/heikoseeberger/akkasse/LineParser.scala
+++ b/akka-sse/src/main/scala/de/heikoseeberger/akkasse/LineParser.scala
@@ -26,7 +26,7 @@ private object LineParser {
   final val LF = '\n'.toByte
 }
 
-private final class LineParser(maxSize: Int) extends StatefulStage[ByteString, String] {
+private final class LineParser(maxLineSize: Int) extends StatefulStage[ByteString, String] {
   import LineParser._
 
   private var buffer = ByteString.empty
@@ -34,10 +34,13 @@ private final class LineParser(maxSize: Int) extends StatefulStage[ByteString, S
   override def initial = new State {
     override def onPush(bytes: ByteString, ctx: Context[String]) = {
       buffer ++= bytes
-      if (buffer.size > maxSize)
-        ctx.fail(new IllegalStateException(s"maxSize of $maxSize exceeded!"))
+
+      val parsedLines = lines().iterator
+
+      if (buffer.size > maxLineSize)
+        ctx.fail(new IllegalStateException(s"maxSize of $maxLineSize exceeded!"))
       else
-        emit(lines().iterator, ctx)
+        emit(parsedLines, ctx)
     }
 
     private def lines(): Vector[String] = {

--- a/akka-sse/src/main/scala/de/heikoseeberger/akkasse/ServerSentEventParser.scala
+++ b/akka-sse/src/main/scala/de/heikoseeberger/akkasse/ServerSentEventParser.scala
@@ -58,7 +58,7 @@ private object ServerSentEventParser {
   }
 }
 
-private final class ServerSentEventParser(maxSize: Int) extends PushStage[String, ServerSentEvent] {
+private final class ServerSentEventParser(maxLineSize: Int) extends PushStage[String, ServerSentEvent] {
   import ServerSentEventParser._
 
   private var lines = Vector.empty[String]
@@ -66,8 +66,8 @@ private final class ServerSentEventParser(maxSize: Int) extends PushStage[String
   override def onPush(line: String, ctx: Context[ServerSentEvent]) =
     if (line.nonEmpty) {
       lines :+= line
-      if (lines.map(_.length).sum > maxSize)
-        ctx.fail(new IllegalStateException(s"maxSize of $maxSize exceeded!"))
+      if (lines.map(_.length).sum > maxLineSize)
+        ctx.fail(new IllegalStateException(s"maxSize of $maxLineSize exceeded!"))
       else
         ctx.pull()
     } else {


### PR DESCRIPTION
This is continuation of #44. I definitely can see your point and think that it's a valid one. The issue in the current implementation of line size check in the `LineParser` is that it does not distinguish between the unfinished line size in the buffer and the buffer that potentially contains more than 1 finished line. That's because I first parse the buffer in order find and remove all of the finished lines from it and only then check it's size in order to validated the size of unfinished line and ensure, that buffer remains bounded. `ServerSentEventParser` will then ensure that all individual finished lines have the right size.

I also renamed `maxSize` to `maxLineSize` in order to better express it's purpose. I wanted to rename it in `EventStreamUnmarshalling` as well, but can't really do it, since it will breaks backwards compatibility.