### PR TITLE
Introduces a pattern for common flows

### DIFF
--- a/akka-sse/src/main/scala/de/heikoseeberger/akkasse/pattern/Streams.scala
+++ b/akka-sse/src/main/scala/de/heikoseeberger/akkasse/pattern/Streams.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.akkasse
+package pattern
+
+import akka.{ Done, NotUsed }
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Flow, Sink, Source }
+
+import scala.concurrent.ExecutionContext
+import scala.util.Try
+
+/**
+ * Common streaming patterns for SSE
+ */
+object Streams {
+
+  /**
+   * Provides a flow representing a common pipeline for handling the establishment of an
+   * SSE event stream and its termination. The flow produces SSE elements. This flow is
+   * intended to be used in conjunction with having established a connection and made a
+   * request. For example:
+   *
+   * {{{
+   * Source
+   *   .single(myRequest)
+   *   .via(myConnection)
+   *   .via(
+   *     sseFlow(
+   *       onSuccess { httpResponse =>
+   *         // Do something given a successful establishment of an event stream
+   *       },
+   *       { outcome =>
+   *         // Do something given that the event stream has terminated
+   *       }
+   *     )
+   *   )
+   *   .runForeach { sseEvent =>
+   *     // Do something for each event
+   *   }
+   * }}}
+   *
+   * @param onResponse the initial response handler
+   * @param onTermination the handler to call when the connection has been terminated
+   * @param ec an execution context for certain parts of the flow mappings
+   * @param mat a materializer for certain parts of the flow
+   * @return a flow that emits ServerSentEvent elements
+   */
+  def sseFlow(onResponse: Try[HttpResponse] => Unit, onTermination: Try[Done] => Unit)(
+    implicit
+    ec: ExecutionContext, mat: ActorMaterializer
+  ): Flow[HttpResponse, ServerSentEvent, NotUsed] =
+    Flow[HttpResponse]
+      .alsoTo(
+        Sink.head.mapMaterializedValue(_.onComplete(onResponse))
+      )
+      .alsoTo(
+        Sink.onComplete(onTermination)
+      )
+      .flatMapConcat { response =>
+        import EventStreamUnmarshalling._
+        val sseEvents =
+          Unmarshal(response)
+            .to[Source[ServerSentEvent, Any]]
+            .map(_.filter(_ != ServerSentEvent.heartbeat))
+        Source
+          .fromFuture(sseEvents)
+          .flatMapConcat(identity)
+      }
+
+  /**
+   * A convenience for wrapping onResponse handlers where the  event
+   * stream HTTP response is successful.
+   *
+   * @param onResponse the handler of the successful HTTP response
+   * @param response the response passed in by the sseFlow, which can have failed
+   */
+  def onSuccess(onResponse: HttpResponse => Unit)(response: Try[HttpResponse]): Unit =
+    for (r <- response if r.status.isSuccess()) onResponse(r)
+}

--- a/akka-sse/src/test/scala/de/heikoseeberger/akkasse/pattern/StreamsSpec.scala
+++ b/akka-sse/src/test/scala/de/heikoseeberger/akkasse/pattern/StreamsSpec.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2015 Heiko Seeberger
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.heikoseeberger.akkasse
+package pattern
+
+import akka.Done
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Keep, Sink, Source }
+import akka.stream.testkit.TestPublisher
+import akka.stream.testkit.scaladsl.TestSource
+import akka.testkit.TestDuration
+import akka.testkit.TestProbe
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.{ Success, Try }
+
+object StreamsSpec {
+
+  /**
+   * Provide a test source probe for an SSE flow that will receive messages for handling the
+   * initial response, termination and as each SSE element is received. Only successful
+   * initial responses are handled by default. Use the "onlyFailedResponses" function below
+   * in order to send through failed ones.
+   */
+  def testSourceProbe(
+    testObserver: ActorRef,
+    responseHandler: (HttpResponse => Unit) => (Try[HttpResponse] => Unit) = Streams.onSuccess
+  )(implicit system: ActorSystem, ec: ExecutionContext, mat: ActorMaterializer): TestPublisher.Probe[HttpResponse] =
+    TestSource.probe[HttpResponse]
+      .via(
+        Streams.sseFlow(
+          responseHandler(r => testObserver ! r),
+          s => testObserver ! s
+        )
+      )
+      .toMat(Sink.foreach(event => testObserver ! event))(Keep.left)
+      .run()
+
+  /**
+   * An initial response handler for accepting only failed responses.
+   */
+  def onOnlyFailedResponses(onResponse: HttpResponse => Unit)(response: Try[HttpResponse]): Unit =
+    response.foreach(r => if (r.status.isFailure()) onResponse(r))
+}
+
+class StreamsSpec extends BaseSpec with ScalaFutures with EventStreamMarshalling {
+
+  import StreamsSpec._
+
+  "An sseFlow" should {
+
+    "call its response handler when successful and its termination handler when done" in {
+      val testObserver = TestProbe()
+
+      val httpResponse = HttpResponse()
+
+      val testSource = testSourceProbe(testObserver.ref)
+      testSource.sendNext(httpResponse)
+      testSource.sendComplete()
+
+      testObserver.expectMsg(httpResponse)
+      testObserver.expectMsg(Success(Done))
+    }
+
+    "not call its response handler when failed" in {
+      val testObserver = TestProbe()
+
+      val httpResponse = HttpResponse(status = StatusCodes.NotFound)
+
+      val testSource = testSourceProbe(testObserver.ref)
+      testSource.sendNext(httpResponse)
+      testSource.sendComplete()
+
+      testObserver.expectMsg(Success(Done))
+    }
+
+    "call its response handler when there is a response whether failed or not" in {
+      val testObserver = TestProbe()
+
+      val httpResponse = HttpResponse(status = StatusCodes.NotFound)
+
+      val testSource = testSourceProbe(testObserver.ref, onOnlyFailedResponses)
+      testSource.sendNext(httpResponse)
+      testSource.sendComplete()
+
+      testObserver.expectMsg(httpResponse)
+      testObserver.expectMsg(Success(Done))
+    }
+
+    "pass through all non heartbeat events" in {
+      val testObserver = TestProbe()
+
+      val sseEvent = ServerSentEvent("Hello World")
+
+      val marshallableResponse =
+        Source.single(sseEvent)
+          .keepAlive(1.millisecond, () => ServerSentEvent.heartbeat): ToResponseMarshallable
+      val marshalledResponse = marshallableResponse(HttpRequest()).futureValue
+
+      val testSource = testSourceProbe(testObserver.ref)
+
+      testSource.sendNext(marshalledResponse)
+      testObserver.expectMsgPF() {
+        case r: HttpResponse if r.status == StatusCodes.OK =>
+      }
+      testObserver.expectMsg(sseEvent)
+      Thread.sleep(10.milliseconds.dilated.toMillis) // Absolutely ensure that no heartbeats come through
+
+      testSource.sendComplete()
+      testObserver.expectMsg(Success(Done))
+    }
+  }
+}


### PR DESCRIPTION
This Connections pattern returns a `Source[ServerSentEvent, NotUsed]` after having performed a request also given a connection. Handlers are invoked for processing both a successful connection to the event stream, and for when the connection terminates.

Heartbeat messages are also filtered out.

Example:

```scala
val myConnection = Http().outgoingConnection(host, port)
val myRequest = Get("/bundles/events")

Source
  .single(myRequest)
  .via(myConnection)
  .via(
    sseFlow(
      success { httpResponse => 
        // Do something given a successful establishment of an event stream
      }, 
      { outcome => 
        // Do something given that the event stream has terminated
      }
    )
  )
  .runForeach { sseEvent =>
    // Do something for each event
  }
```
Fixes #99 