### PR TITLE
Improve test resiliency

### DIFF
--- a/akka-sse/src/test/scala/de/heikoseeberger/akkasse/pattern/StreamsSpec.scala
+++ b/akka-sse/src/test/scala/de/heikoseeberger/akkasse/pattern/StreamsSpec.scala
@@ -77,8 +77,12 @@ class StreamsSpec extends BaseSpec with ScalaFutures with EventStreamMarshalling
       testSource.sendNext(httpResponse)
       testSource.sendComplete()
 
-      testObserver.expectMsg(httpResponse)
-      testObserver.expectMsg(Success(Done))
+      testObserver.expectMsgPF() {
+        case `httpResponse` =>
+          testObserver.expectMsg(Success(Done))
+        case Success(Done) =>
+          testObserver.expectMsg(httpResponse)
+      }
     }
 
     "not call its response handler when failed" in {
@@ -102,8 +106,12 @@ class StreamsSpec extends BaseSpec with ScalaFutures with EventStreamMarshalling
       testSource.sendNext(httpResponse)
       testSource.sendComplete()
 
-      testObserver.expectMsg(httpResponse)
-      testObserver.expectMsg(Success(Done))
+      testObserver.expectMsgPF() {
+        case `httpResponse` =>
+          testObserver.expectMsg(Success(Done))
+        case Success(Done) =>
+          testObserver.expectMsg(httpResponse)
+      }
     }
 
     "pass through all non heartbeat events" in {


### PR DESCRIPTION
Given that we're using the same test probe to observe a number of events, cope with the parallel nature of things.

Fixes #106 