### PR TITLE
Allow single space data

### DIFF
--- a/akka-sse/src/main/scala/de/heikoseeberger/akkasse/ServerSentEvent.scala
+++ b/akka-sse/src/main/scala/de/heikoseeberger/akkasse/ServerSentEvent.scala
@@ -197,7 +197,7 @@ final case class ServerSentEvent(data: String,
           builder.append(c)
           if (c == '\n') index + 1 else addLine(index + 1)
         }
-      builder.append("data:")
+      builder.append("data: ")
       addLine(index) match {
         case -1 => builder.append('\n')
         case i  => appendData(s, i)
@@ -205,10 +205,10 @@ final case class ServerSentEvent(data: String,
     }
     appendData(data)
     if (eventType.isDefined)
-      builder.append("event:").append(eventType.get).append('\n')
-    if (id.isDefined) builder.append("id:").append(id.get).append('\n')
+      builder.append("event: ").append(eventType.get).append('\n')
+    if (id.isDefined) builder.append("id: ").append(id.get).append('\n')
     if (retry.isDefined)
-      builder.append("retry:").append(retry.get).append('\n')
+      builder.append("retry: ").append(retry.get).append('\n')
     builder.append('\n').toString
   }
 }

--- a/akka-sse/src/test/scala/de/heikoseeberger/akkasse/ServerSentEventSpec.scala
+++ b/akka-sse/src/test/scala/de/heikoseeberger/akkasse/ServerSentEventSpec.scala
@@ -47,29 +47,29 @@ class ServerSentEventSpec
 
   "Calling toString" should {
     "return a single data line for single line message" in {
-      val event = ServerSentEvent("line")
-      event.toString shouldBe "data:line\n\n"
+      val event = ServerSentEvent(" ")
+      event.toString shouldBe "data:  \n\n"
     }
 
     "return multiple data lines for a multi-line message" in {
       val event = ServerSentEvent("line1\nline2\n")
-      event.toString shouldBe "data:line1\ndata:line2\ndata:\n\n"
+      event.toString shouldBe "data: line1\ndata: line2\ndata: \n\n"
     }
 
     "return multiple data lines and an event line for a multi-line message with a defined event type" in {
       val event = ServerSentEvent("line1\nline2", "event-type")
-      event.toString shouldBe "data:line1\ndata:line2\nevent:event-type\n\n"
+      event.toString shouldBe "data: line1\ndata: line2\nevent: event-type\n\n"
     }
 
     "return a single id field after the data fields" in {
       val event = ServerSentEvent("line1", eventType = None, id = Some("1"))
-      event.toString shouldBe "data:line1\nid:1\n\n"
+      event.toString shouldBe "data: line1\nid: 1\n\n"
     }
 
     "return a single retry field after the data fields" in {
       val event =
         ServerSentEvent("line1", eventType = None, id = None, retry = Some(42))
-      event.toString shouldBe "data:line1\nretry:42\n\n"
+      event.toString shouldBe "data: line1\nretry: 42\n\n"
     }
   }
 


### PR DESCRIPTION
As the first space after a colon is ignored, it's necessary to serialize `ServerSentEvent`s such that each identifier-colon prefix is followed by a space by default.