### PR TITLE
Support sending a single "retry" line

### DIFF
--- a/akka-sse/src/main/scala/de/heikoseeberger/akkasse/ServerSentEvent.scala
+++ b/akka-sse/src/main/scala/de/heikoseeberger/akkasse/ServerSentEvent.scala
@@ -42,6 +42,16 @@ object ServerSentEvent {
   }
 
   /**
+    * A retry [[ServerSentEvent]] without any data associated.
+    * @param retry the reconnection time in milliseconds.
+    */
+  case class Retry(retry: Int) extends EventStreamElement {
+    require(retry > 0L, "Retry must be a positive number!")
+
+    override def encode = ByteString(s"retry: $retry\n\n", UTF_8.name)
+  }
+
+  /**
     * An eventId which resets the last event ID to the empty string, meaning no `Last-Event-ID` header will be sent
     * in the event of a reconnection being attempted.
     */

--- a/akka-sse/src/test/scala/de/heikoseeberger/akkasse/ServerSentEventSpec.scala
+++ b/akka-sse/src/test/scala/de/heikoseeberger/akkasse/ServerSentEventSpec.scala
@@ -42,6 +42,9 @@ class ServerSentEventSpec
         "data",
         retry = Some(-1)
       )
+      an[IllegalArgumentException] should be thrownBy ServerSentEvent.Retry(
+        -1
+      )
     }
   }
 
@@ -79,6 +82,14 @@ class ServerSentEventSpec
         val event = ServerSentEvent(data)
         event.encode.utf8String shouldBe event.toString
       }
+    }
+  }
+
+  "Retry" should {
+    "create a single retry field for single line message" in {
+      val event =
+        ServerSentEvent.Retry(42)
+      event.encode.utf8String shouldBe "retry: 42\n\n"
     }
   }
 }


### PR DESCRIPTION
The intended use case is that when an SSE connection is established, send a single "retry:1000" (without any data associated to it) then wait till an event reaches.
