### PR TITLE
use a newer scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -2,7 +2,8 @@ style = defaultWithAlign
 
 danglingParentheses        = true
 indentOperator             = spray
-maxColumn                  = 120
-spaces.inImportCurlyBraces = true
+maxColumn                  = 100
+project.excludeFilters     = [".*\\.sbt"]
 rewrite.rules              = [RedundantBraces, RedundantParens, SortImports]
+spaces.inImportCurlyBraces = true
 unindentTopLevelOperators  = true

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,6 @@ lazy val library =
 
 lazy val settings =
   commonSettings ++
-  scalafmtSettings ++
   gitSettings ++
   headerSettings ++
   sonatypeSettings
@@ -111,14 +110,6 @@ lazy val commonSettings =
     unmanagedSourceDirectories.in(Test) :=
       Seq(scalaSource.in(Test).value, javaSource.in(Test).value)
 )
-
-lazy val scalafmtSettings =
-  reformatOnCompileSettings ++
-  Seq(
-    formatSbtFiles := false,
-    scalafmtConfig := Some(baseDirectory.in(ThisBuild).value / ".scalafmt.conf"),
-    ivyScala := ivyScala.value.map(_.copy(overrideScalaVersion = sbtPlugin.value)) // TODO Remove once this workaround no longer needed (https://github.com/sbt/sbt/issues/2786)!
-  )
 
 lazy val gitSettings =
   Seq(

--- a/core/src/main/scala/de/heikoseeberger/akkasse/EventStreamUnmarshalling.scala
+++ b/core/src/main/scala/de/heikoseeberger/akkasse/EventStreamUnmarshalling.scala
@@ -61,7 +61,10 @@ trait EventStreamUnmarshalling {
     val lineParser  = new LineParser(_maxLineSize)
     val eventParser = new ServerSentEventParser(_maxEventSize)
     def unmarshal(entity: HttpEntity) =
-      entity.withoutSizeLimit.dataBytes.via(lineParser).via(eventParser).mapMaterializedValue(_ => NotUsed: NotUsed)
+      entity.withoutSizeLimit.dataBytes
+        .via(lineParser)
+        .via(eventParser)
+        .mapMaterializedValue(_ => NotUsed: NotUsed)
     Unmarshaller.strict(unmarshal).forContentTypes(`text/event-stream`)
   }
 }

--- a/core/src/main/scala/de/heikoseeberger/akkasse/LineParser.scala
+++ b/core/src/main/scala/de/heikoseeberger/akkasse/LineParser.scala
@@ -28,9 +28,11 @@ private object LineParser {
   private final val lf = '\n'.toByte
 }
 
-private final class LineParser(maxLineSize: Int) extends GraphStage[FlowShape[ByteString, String]] {
+private final class LineParser(maxLineSize: Int)
+    extends GraphStage[FlowShape[ByteString, String]] {
 
-  override val shape = FlowShape(Inlet[ByteString]("LineParser.in"), Outlet[String]("LineParser.out"))
+  override val shape =
+    FlowShape(Inlet[ByteString]("LineParser.in"), Outlet[String]("LineParser.out"))
 
   override def createLogic(attributes: Attributes) =
     new GraphStageLogic(shape) with InHandler with OutHandler {

--- a/core/src/main/scala/de/heikoseeberger/akkasse/ServerSentEventParser.scala
+++ b/core/src/main/scala/de/heikoseeberger/akkasse/ServerSentEventParser.scala
@@ -84,7 +84,8 @@ private object ServerSentEventParser {
   private val linePattern = """([^:]+): ?(.*)""".r
 }
 
-private final class ServerSentEventParser(maxEventSize: Int) extends GraphStage[FlowShape[String, ServerSentEvent]] {
+private final class ServerSentEventParser(maxEventSize: Int)
+    extends GraphStage[FlowShape[String, ServerSentEvent]] {
 
   override val shape = FlowShape(
     Inlet[String]("ServerSentEventParser.in"),

--- a/core/src/main/scala/de/heikoseeberger/akkasse/japi/EventStreamUnmarshallingConverter.scala
+++ b/core/src/main/scala/de/heikoseeberger/akkasse/japi/EventStreamUnmarshallingConverter.scala
@@ -20,7 +20,9 @@ import akka.NotUsed
 import akka.http.javadsl.model.HttpEntity
 import akka.http.scaladsl.unmarshalling.Unmarshaller
 import akka.stream.javadsl.Source
-import de.heikoseeberger.akkasse.EventStreamUnmarshalling.{ fromEventStream => fromEventStreamScala }
+import de.heikoseeberger.akkasse.EventStreamUnmarshalling.{
+  fromEventStream => fromEventStreamScala
+}
 
 private object EventStreamUnmarshallingConverter {
 

--- a/core/src/test/scala/de/heikoseeberger/akkasse/EventStreamUnmarshallingSpec.scala
+++ b/core/src/test/scala/de/heikoseeberger/akkasse/EventStreamUnmarshallingSpec.scala
@@ -54,8 +54,10 @@ object EventStreamUnmarshallingSpec {
               complete(
                 HttpResponse(
                   BadRequest,
-                  entity = HttpEntity(`text/event-stream`,
-                                      "Integral number expected for Last-Event-ID header!".getBytes(UTF_8))
+                  entity = HttpEntity(
+                    `text/event-stream`,
+                    "Integral number expected for Last-Event-ID header!".getBytes(UTF_8)
+                  )
                 )
               )
           }
@@ -99,7 +101,10 @@ class EventStreamUnmarshallingSpec extends BaseSpec {
       val events = 1.to(666).map(n => ServerSentEvent(Some(n.toString)))
       val data   = Source(events).map(_.encode)
       val entity = HttpEntity(`text/event-stream`, data)
-      Unmarshal(entity).to[Source[ServerSentEvent, NotUsed]].flatMap(_.runWith(Sink.seq)).map(_ shouldBe events)
+      Unmarshal(entity)
+        .to[Source[ServerSentEvent, NotUsed]]
+        .flatMap(_.runWith(Sink.seq))
+        .map(_ shouldBe events)
     }
 
     "not be limited" in {
@@ -109,7 +114,9 @@ class EventStreamUnmarshallingSpec extends BaseSpec {
       Http()
         .singleRequest(Get(s"http://$host:$port"))
         .flatMap {
-          Unmarshal(_).to[Source[ServerSentEvent, NotUsed]].flatMap(_.take(nrOfSamples).runWith(Sink.ignore))
+          Unmarshal(_)
+            .to[Source[ServerSentEvent, NotUsed]]
+            .flatMap(_.take(nrOfSamples).runWith(Sink.ignore))
         }
         .map(_ shouldBe Done)
         .andThen { case _ => system.stop(server) }

--- a/jmh/src/main/scala/de/heikoseeberger/akkasse/LineParserBenchmark.scala
+++ b/jmh/src/main/scala/de/heikoseeberger/akkasse/LineParserBenchmark.scala
@@ -45,9 +45,10 @@ class LineParserBenchmark {
 
   @Benchmark
   def benchmark(): Unit = {
-    implicit val system    = state.system
-    implicit val mat       = state.mat
-    def next(last: String) = if (last == "event:foo\ndata:") "bar\ndata:baz\n\n" else "event:foo\ndata:"
+    implicit val system = state.system
+    implicit val mat    = state.mat
+    def next(last: String) =
+      if (last == "event:foo\ndata:") "bar\ndata:baz\n\n" else "event:foo\ndata:"
     val done =
       Source
         .fromIterator(() => Iterator.iterate("event:foo\ndata:")(next))

--- a/project/AutomateScalafmtPlugin.scala
+++ b/project/AutomateScalafmtPlugin.scala
@@ -1,0 +1,65 @@
+import org.scalafmt.bootstrap.ScalafmtBootstrap
+import org.scalafmt.sbt.ScalafmtPlugin
+import sbt._
+import sbt.Keys._
+import sbt.inc.Analysis
+
+object AutomateScalafmtPlugin extends AutoPlugin {
+
+  object autoImport {
+    def automateScalafmtFor(configurations: Configuration*): Seq[Setting[_]] =
+      configurations.flatMap { c =>
+        inConfig(c)(
+          Seq(
+            compileInputs.in(compile) := {
+              scalafmtInc.value
+              compileInputs.in(compile).value
+            },
+            sourceDirectories.in(scalafmtInc) := Seq(scalaSource.value),
+            scalafmtInc := {
+              val cache   = streams.value.cacheDirectory / "scalafmt"
+              val include = includeFilter.in(scalafmtInc).value
+              val exclude = excludeFilter.in(scalafmtInc).value
+              val sources =
+                sourceDirectories
+                  .in(scalafmtInc)
+                  .value
+                  .descendantsExcept(include, exclude)
+                  .get
+                  .toSet
+              def format(handler: Set[File] => Unit, msg: String) = {
+                def update(handler: Set[File] => Unit, msg: String)(
+                    in: ChangeReport[File], out: ChangeReport[File]) = {
+                  val label = Reference.display(thisProjectRef.value)
+                  val files = in.modified -- in.removed
+                  Analysis
+                    .counted("Scala source", "", "s", files.size)
+                    .foreach(count => streams.value.log.info(s"$msg $count in $label ..."))
+                  handler(files)
+                  files
+                }
+                FileFunction.cached(cache)(FilesInfo.hash,
+                                           FilesInfo.exists)(update(handler, msg))(sources)
+              }
+              def formattingHandler(files: Set[File]) =
+                if (files.nonEmpty) {
+                  val filesArg = files.map(_.getAbsolutePath).mkString(",")
+                  ScalafmtBootstrap.main(List("--non-interactive", "-i", "-f", filesArg))
+                }
+              format(formattingHandler, "Formatting")
+              format(_ => (), "Reformatted") // Recalculate the cache
+            }
+          )
+        )
+      }
+  }
+
+  private val scalafmtInc = taskKey[Unit]("Incrementally format modified sources")
+
+  override def requires = ScalafmtPlugin
+
+  override def trigger = allRequirements
+
+  override def projectSettings =
+    (includeFilter.in(scalafmtInc) := "*.scala") +: autoImport.automateScalafmtFor(Compile, Test)
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.dwijnand"       % "sbt-travisci" % "1.0.0-M4")
-addSbtPlugin("com.geirsson"       % "sbt-scalafmt" % "0.4.10")
+addSbtPlugin("com.geirsson"       % "sbt-scalafmt" % "0.5.6")
 addSbtPlugin("com.jsuereth"       % "sbt-pgp"      % "1.0.0")
 addSbtPlugin("com.typesafe.sbt"   % "sbt-git"      % "0.8.5")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"   % "1.6.0")


### PR DESCRIPTION
this makes it easier for us to keep akka-sse in the Scala community
build, because the newer scalafmt is more dbuild-friendly.  (probably
there are lots of other improvements in the new version?)

note that the newer version no longer directly supports
reformat-on-compile; a possible workaround is shown at
https://olafurpg.github.io/scalafmt/#sbt